### PR TITLE
Add build.sh cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ _Example `config.js` File_
 
 ### 2) Start The Application
 
-Run the application locally with this command
+Run the application locally with this command. Accepts cli arguments `env`
 
-	$bash build.sh
+	$bash build.sh --env development
 
-This bash script orchestrates all build steps irregardless of language. __If adding a new build step, dependency or language it must ultimately be configured to run via this bash script.__
+This bash script orchestrates all build steps irregardless of language. __If adding a new build step, dependency or language it must ultimately be configured to run via this bash script.__ 
 
 
 ## Developing

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+# ! /bin/bash
 
 # Setup npm
 echo 'NPM INSTALL'
@@ -6,4 +6,4 @@ npm install
 echo 'RUNNING TESTS'
 npm test
 echo 'STARTING APPLICATION'
-npm start "$@"
+./node_modules/.bin/gulp default $@

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,12 +2,17 @@
 
 var gulp = require('gulp')
 var plugins = require('gulp-load-plugins')()
+var minimist = require('minimist')
+var assign = require('lodash-node/modern/object/assign')
 
-function getTask(task) {
-    return require('./tasks/' + task)(gulp, plugins)
+var env = {
+  string: 'env',
+  default: {
+    env: process.env.NODE_ENV || 'development'
+  }
 }
-
-gulp.opts = {
+var argv = minimist(process.argv.slice(2), env)
+var options = {
   DEST: 'public',
   APP_ENTRY: 'app/app.js',
   LESS: [
@@ -20,6 +25,12 @@ gulp.opts = {
     'app/vendors/highcharts/highcharts-theme.js'
   ]
 }
+
+function getTask(task) {
+    return require('./tasks/' + task)(gulp, plugins)
+}
+
+gulp.opts = assign(options, argv)
 
 // Load Tasks
 gulp.task('html', getTask('html'))

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",
     "gulp-watch": "^4.3.3",
+    "lodash-node": "^3.10.1",
+    "minimist": "^1.2.0",
     "riotify": "^0.1.2",
     "standard": "^4.5.4",
     "tap": "^1.3.1",

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -1,8 +1,9 @@
 module.exports = function (gulp, plugins) {
   return function () {
+    var port = gulp.opts.env == 'development' ? 8001 : 80
     plugins.connect.server({
       root: gulp.opts.DEST,
-      port: 8001,
+      port: port,
       livereload: true
     })
   }


### PR DESCRIPTION
Adding the ability to parse command line options in the gulpfile. Gulp now accepts an `--env` option to make processing decisions.